### PR TITLE
Test enhancements (updated)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Constants\\Tests\\": "tests/"
+            "Tests\\": "tests/"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,20 @@
         "issues": "https://github.com/stevegrunwell/time-constants/issues",
         "source": "https://github.com/stevegrunwell/time-constants"
     },
-    "require": {},
+    "require": {
+        "php": "^7.0"
+    },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",
         "phpunit/phpunit": "^6.0"
     },
     "autoload": {
         "files": ["constants.php"]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Constants\\Tests\\": "tests/"
+        }
     },
     "config": {
         "preferred-install": "dist",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,7 @@
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
+    bootstrap="vendor/autoload.php"
     >
     <testsuites>
         <testsuite name="Core">

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Constants\Tests;
+namespace Tests;
 
 /**
  * Tests the definition of time constants.

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace Constants\Tests;
+
 /**
  * Tests the definition of time constants.
  *
@@ -13,6 +16,10 @@ class ConstantsTest extends TestCase
      * Ensure that each constant is defined and numeric.
      *
      * @dataProvider constantsProvider()
+     *
+     * @param string $constant
+     *
+     * @return void
      */
     public function testConstantsAreDefined($constant)
     {
@@ -22,6 +29,8 @@ class ConstantsTest extends TestCase
 
     /**
      * Provides a list of all constants defined by this package.
+     *
+     * @return array
      */
     public function constantsProvider()
     {


### PR DESCRIPTION
This PR replaces #4, with one change: use `Tests` instead of `Constants\Tests` as the namespace for the test files.

Closes #4.