### PR TITLE
Define an archive.exclude section of the composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,12 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "optimize-autoloader": true
+    },
+    "archive": {
+        "exclude": [
+            ".*",
+            "phpunit.xml.dist",
+            "tests"
+        ]
     }
 }


### PR DESCRIPTION
This brings down the download size slightly by excluding tings like GitHub workflows and tests, which aren't necessary for apps implementing these constants.